### PR TITLE
Fix crash when typename is existing object type that is not a NodeObjectType

### DIFF
--- a/ariadne_relay/node.py
+++ b/ariadne_relay/node.py
@@ -108,7 +108,8 @@ def _get_instance_resolver_and_node_id(
     except Exception as e:
         raise ValueError(f'Invalid ID "{raw_id}"') from e
     node_type = info.schema.type_map.get(node_type_name)
-    if node_type is None:
+    extensions = getattr(node_type, "extensions", None) or {}
+    instance_resolver = extensions.get(INSTANCE_RESOLVER)
+    if instance_resolver is None:
         return None
-    instance_resolver = getattr(node_type, "extensions", {}).get(INSTANCE_RESOLVER)
     return instance_resolver, node_id

--- a/tests/asgi/test_query_execution.py
+++ b/tests/asgi/test_query_execution.py
@@ -34,6 +34,27 @@ def test_node_query(
     }
 
 
+def test_node_query_existing_non_node_typename(
+    client: TestClient, node_query: str
+) -> None:
+    global_id = to_global_id("Bar", "bar")
+    response = client.post(
+        "/",
+        json={
+            "query": node_query,
+            "variables": {
+                "id": global_id,
+            },
+        },
+    )
+    assert response.status_code == 200
+    assert response.json() == {
+        "data": {
+            "node": None,
+        }
+    }
+
+
 def test_connection_query(
     client: TestClient,
     connection_query: str,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 from typing import Dict
 
-from ariadne import InterfaceType, make_executable_schema
+from ariadne import InterfaceType, make_executable_schema, ObjectType
 from graphql import GraphQLSchema
 import pytest
 
@@ -51,6 +51,10 @@ def type_defs() -> str:
             pageInfo: PageInfo!
             edges: [FooEdge]!
         }
+
+        type Bar {
+            id: String!
+        }
     """
 
 
@@ -82,15 +86,21 @@ def foo_type(foo_nodes: Dict[str, Foo]) -> NodeObjectType:
 
 
 @pytest.fixture
+def bar_type() -> ObjectType:
+    return ObjectType("Bar")
+
+
+@pytest.fixture
 def schema(
     type_defs: str,
     query_type: RelayQueryType,
     node_interface_type: InterfaceType,
     foo_type: NodeObjectType,
+    bar_type: ObjectType,
 ) -> GraphQLSchema:
     return make_executable_schema(
         type_defs,
-        [query_type, node_interface_type, foo_type],
+        [query_type, node_interface_type, foo_type, bar_type],
     )
 
 

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -35,3 +35,17 @@ def test_node_resolver(type_defs: str, node_query: str) -> None:
                 "id": global_id,
             }
         }
+
+
+def test_non_node_typename(type_defs: str, node_query: str) -> None:
+    query_type = QueryType()
+    query_type.set_field("node", resolve_node_query_sync)
+    node_interface = InterfaceType(
+        "Node",
+        type_resolver=lambda obj, *_: obj.__class__.__name__,
+    )
+    schema = make_executable_schema(type_defs, query_type, node_interface)
+    global_id = to_global_id("Bar", "bar")
+    result = graphql_sync(schema, node_query, variable_values={"id": global_id})
+    assert result.errors is None
+    assert result.data == {"node": None}


### PR DESCRIPTION
Closes #6 