### PR TITLE
Add explicit paths to mypy files setup

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -13,7 +13,7 @@ no_lines_before = LOCALFOLDER
 profile = google
 
 [mypy]
-files = .
+files = ariadne_relay, tests
 follow_imports = silent
 ignore_missing_imports = True
 check_untyped_defs = True


### PR DESCRIPTION
Avoids `Duplicate module named 'ariadne_relay' (also at './ariadne_relay/__init__.py')`