### PR TITLE
Implement NodeInterfaceType

### DIFF
--- a/ariadne_relay/__init__.py
+++ b/ariadne_relay/__init__.py
@@ -21,7 +21,12 @@ from .connection import (
     SnakeCasePageInfoType,
 )
 from .interfaces import RelayInterfaceType
-from .node import NodeObjectType, resolve_node_query, resolve_node_query_sync
+from .node import (
+    NodeInterfaceType,
+    NodeObjectType,
+    resolve_node_query,
+    resolve_node_query_sync,
+)
 from .objects import RelayMutationType, RelayObjectType, RelayQueryType
 
 __all__ = [
@@ -34,6 +39,7 @@ __all__ = [
     "EdgeConstructor",
     "EdgeType",
     "from_global_id",
+    "NodeInterfaceType",
     "NodeObjectType",
     "PageInfo",
     "PageInfoConstructor",

--- a/ariadne_relay/node.py
+++ b/ariadne_relay/node.py
@@ -1,9 +1,16 @@
 import asyncio
 from typing import Any, Awaitable, Callable, cast, Optional, Tuple, Union
 
-from graphql import default_field_resolver, GraphQLObjectType, GraphQLResolveInfo
+from ariadne.types import Resolver
+from graphql import (
+    default_field_resolver,
+    GraphQLNamedType,
+    GraphQLObjectType,
+    GraphQLResolveInfo,
+)
 from graphql_relay import from_global_id, to_global_id
 
+from .interfaces import RelayInterfaceType
 from .objects import RelayObjectType
 from .utils import is_coroutine_callable
 
@@ -13,61 +20,13 @@ NodeIdResolver = Union[NodeIdAwaitable, NodeIdCallable]
 NodeInstanceAwaitable = Callable[..., Awaitable[Any]]
 NodeInstanceCallable = Callable[..., Any]
 NodeInstanceResolver = Union[NodeInstanceAwaitable, NodeInstanceCallable]
+NodeTypenameAwaitable = Callable[..., Awaitable[str]]
+NodeTypenameCallable = Callable[..., str]
+NodeTypenameResolver = Union[NodeTypenameAwaitable, NodeTypenameCallable]
 
+ID_RESOLVER = "ariadne_relay_node_id_resolver"
 INSTANCE_RESOLVER = "ariadne_relay_node_instance_resolver"
-
-
-class NodeObjectType(RelayObjectType):
-    _resolve_id: NodeIdResolver
-    _resolve_instance: Optional[NodeInstanceResolver]
-
-    def __init__(
-        self,
-        name: str,
-        *,
-        id_resolver: NodeIdResolver = default_field_resolver,
-        instance_resolver: Optional[NodeInstanceResolver] = None,
-    ) -> None:
-        super().__init__(name)
-        self._resolve_id = id_resolver
-        self._resolve_instance = instance_resolver
-
-    def bind_resolvers_to_graphql_type(
-        self, graphql_type: GraphQLObjectType, replace_existing: bool = True
-    ) -> None:
-        super().bind_resolvers_to_graphql_type(graphql_type, replace_existing)
-        if "id" not in graphql_type.fields:
-            raise ValueError(f"Field id is not defined on type {self.name}")
-        if graphql_type.fields["id"].resolve is None or replace_existing:
-            if is_coroutine_callable(self._resolve_id):
-                graphql_type.fields["id"].resolve = self._resolve_node_id_field
-            else:
-                graphql_type.fields["id"].resolve = self._resolve_node_id_field_sync
-        if self._resolve_instance is not None:
-            graphql_type.extensions = graphql_type.extensions or {}
-            graphql_type.extensions[INSTANCE_RESOLVER] = self._resolve_instance
-
-    async def _resolve_node_id_field(self, obj: Any, info: GraphQLResolveInfo) -> str:
-        resolve_id = cast(NodeIdAwaitable, self._resolve_id)
-        return to_global_id(self.name, await resolve_id(obj, info))
-
-    def _resolve_node_id_field_sync(self, obj: Any, info: GraphQLResolveInfo) -> str:
-        resolve_id = cast(NodeIdCallable, self._resolve_id)
-        return to_global_id(self.name, resolve_id(obj, info))
-
-    def set_id_resolver(self, id_resolver: NodeIdResolver) -> NodeIdResolver:
-        self._resolve_id = id_resolver
-        return id_resolver
-
-    def set_instance_resolver(
-        self, instance_resolver: NodeInstanceResolver
-    ) -> NodeInstanceResolver:
-        self._resolve_instance = instance_resolver
-        return instance_resolver
-
-    # Alias resolvers for consistent decorator API
-    id_resolver = set_id_resolver
-    instance_resolver = set_instance_resolver
+TYPENAME_RESOLVER = "ariadne_relay_node_typename_resolver"
 
 
 async def resolve_node_query(
@@ -99,6 +58,126 @@ def resolve_node_query_sync(
     return None
 
 
+class NodeType:
+    name: str
+    _resolve_id: Optional[NodeIdResolver]
+    _resolve_instance: Optional[NodeInstanceResolver]
+    _resolve_typename: Optional[NodeTypenameResolver]
+
+    def bind_node_resolvers_to_graphql_type(
+        self, graphql_type: GraphQLObjectType, replace_existing: bool = True
+    ) -> None:
+        if "id" not in graphql_type.fields:
+            raise ValueError(f"Field id is not defined on type {self.name}")
+        if graphql_type.fields["id"].resolve is None or replace_existing:
+            if is_coroutine_callable(self._resolve_typename) or is_coroutine_callable(
+                self._resolve_id
+            ):
+                graphql_type.fields["id"].resolve = self._resolve_node_id_field
+            else:
+                graphql_type.fields["id"].resolve = self._resolve_node_id_field_sync
+        if self._resolve_id is not None:
+            _set_extension(
+                graphql_type,
+                ID_RESOLVER,
+                self._resolve_id,
+                replace_existing,
+            )
+        if self._resolve_instance is not None:
+            _set_extension(
+                graphql_type,
+                INSTANCE_RESOLVER,
+                self._resolve_instance,
+                replace_existing,
+            )
+        if self._resolve_typename is not None:
+            _set_extension(
+                graphql_type,
+                TYPENAME_RESOLVER,
+                self._resolve_typename,
+                replace_existing,
+            )
+
+    async def _resolve_node_id_field(self, obj: Any, info: GraphQLResolveInfo) -> str:
+        node_typename = self._resolve_node_typename(obj, info)
+        if asyncio.iscoroutine(node_typename):
+            node_typename = await cast(Awaitable[str], node_typename)
+        node_id = self._resolve_node_id(obj, info)
+        if asyncio.iscoroutine(node_id):
+            node_id = await cast(Awaitable[str], node_id)
+        return to_global_id(cast(str, node_typename), cast(str, node_id))
+
+    def _resolve_node_id_field_sync(self, obj: Any, info: GraphQLResolveInfo) -> str:
+        node_typename = cast(str, self._resolve_node_typename(obj, info))
+        node_id = cast(str, self._resolve_node_id(obj, info))
+        return to_global_id(node_typename, node_id)
+
+    def _resolve_node_id(
+        self,
+        obj: Any,
+        info: GraphQLResolveInfo,
+    ) -> Union[str, Awaitable[str]]:
+        resolve_id = cast(
+            Optional[NodeIdResolver],
+            _get_extension(info.parent_type, ID_RESOLVER),
+        )
+        if resolve_id:
+            return resolve_id(obj, info)
+        return cast(str, default_field_resolver(obj, info))
+
+    def _resolve_node_typename(
+        self,
+        obj: Any,
+        info: GraphQLResolveInfo,
+    ) -> Union[str, Awaitable[str]]:
+        resolve_typename = cast(
+            Optional[NodeTypenameResolver],
+            _get_extension(info.parent_type, TYPENAME_RESOLVER),
+        )
+        if resolve_typename:
+            return resolve_typename(obj, info)
+        return info.parent_type.name
+
+    def set_id_resolver(self, id_resolver: NodeIdResolver) -> NodeIdResolver:
+        self._resolve_id = id_resolver
+        return id_resolver
+
+    def set_instance_resolver(
+        self, instance_resolver: NodeInstanceResolver
+    ) -> NodeInstanceResolver:
+        self._resolve_instance = instance_resolver
+        return instance_resolver
+
+    def set_typename_resolver(
+        self,
+        typename_resolver: NodeTypenameResolver,
+    ) -> NodeTypenameResolver:
+        self._resolve_typename = typename_resolver
+        return typename_resolver
+
+    # Alias resolvers for consistent decorator API
+    id_resolver = set_id_resolver
+    instance_resolver = set_instance_resolver
+    typename_resolver = set_typename_resolver
+
+
+def _get_extension(graphql_type: GraphQLNamedType, name: str) -> Any:
+    if not isinstance(graphql_type.extensions, dict):
+        return None
+    return graphql_type.extensions.get(name)
+
+
+def _set_extension(
+    graphql_type: GraphQLNamedType,
+    name: str,
+    value: Any,
+    replace_existing: bool,
+) -> None:
+    graphql_type.extensions = graphql_type.extensions or {}
+    if name not in graphql_type.extensions or replace_existing:
+        graphql_type.extensions[name] = value
+
+
 def _get_instance_resolver_and_node_id(
     info: GraphQLResolveInfo,
     raw_id: str,
@@ -108,8 +187,57 @@ def _get_instance_resolver_and_node_id(
     except Exception as e:
         raise ValueError(f'Invalid ID "{raw_id}"') from e
     node_type = info.schema.type_map.get(node_type_name)
-    extensions = getattr(node_type, "extensions", None) or {}
-    instance_resolver = extensions.get(INSTANCE_RESOLVER)
-    if instance_resolver is None:
-        return None
-    return instance_resolver, node_id
+    if node_type:
+        instance_resolver = _get_extension(node_type, INSTANCE_RESOLVER)
+        if instance_resolver:
+            return instance_resolver, node_id
+    return None
+
+
+class NodeObjectType(NodeType, RelayObjectType):
+    def __init__(
+        self,
+        name: str,
+        *,
+        id_resolver: Optional[NodeIdResolver] = None,
+        instance_resolver: Optional[NodeInstanceResolver] = None,
+        typename_resolver: Optional[NodeTypenameResolver] = None,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(name)
+        self._resolve_id = id_resolver
+        self._resolve_instance = instance_resolver
+        self._resolve_typename = typename_resolver
+
+    def bind_resolvers_to_graphql_type(
+        self,
+        graphql_type: GraphQLObjectType,
+        replace_existing: bool = True,
+    ) -> None:
+        super().bind_resolvers_to_graphql_type(graphql_type, replace_existing)
+        self.bind_node_resolvers_to_graphql_type(graphql_type, replace_existing)
+
+
+class NodeInterfaceType(NodeType, RelayInterfaceType):
+    def __init__(
+        self,
+        name: str,
+        type_resolver: Optional[Resolver] = None,
+        *,
+        id_resolver: Optional[NodeIdResolver] = None,
+        instance_resolver: Optional[NodeInstanceResolver] = None,
+        typename_resolver: Optional[NodeTypenameResolver] = None,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(name, type_resolver)
+        self._resolve_id = id_resolver
+        self._resolve_instance = instance_resolver
+        self._resolve_typename = typename_resolver
+
+    def bind_resolvers_to_graphql_type(
+        self,
+        graphql_type: GraphQLObjectType,
+        replace_existing: bool = True,
+    ) -> None:
+        super().bind_resolvers_to_graphql_type(graphql_type, replace_existing)
+        self.bind_node_resolvers_to_graphql_type(graphql_type, replace_existing)

--- a/tests/asgi/test_query_execution.py
+++ b/tests/asgi/test_query_execution.py
@@ -3,10 +3,10 @@ from typing import Dict
 from graphql_relay import offset_to_cursor, to_global_id
 from starlette.testclient import TestClient
 
-from ..conftest import Foo
+from ..conftest import Foo, Qux
 
 
-def test_node_query(
+def test_query_node_instance_resolver(
     client: TestClient,
     node_query: str,
     foo_nodes: Dict[str, Foo],
@@ -34,8 +34,37 @@ def test_node_query(
     }
 
 
-def test_node_query_existing_non_node_typename(
-    client: TestClient, node_query: str
+def test_query_node_interface_instance_resolver(
+    client: TestClient,
+    node_query: str,
+    qux_nodes: Dict[str, Qux],
+) -> None:
+    test_node = next(iter(qux_nodes.values()))
+    type_name = test_node.__class__.__name__
+    global_id = to_global_id("Baz", str(test_node.id))
+    response = client.post(
+        "/",
+        json={
+            "query": node_query,
+            "variables": {
+                "id": global_id,
+            },
+        },
+    )
+    assert response.status_code == 200
+    assert response.json() == {
+        "data": {
+            "node": {
+                "__typename": type_name,
+                "id": global_id,
+            }
+        }
+    }
+
+
+def test_query_non_node_typename(
+    client: TestClient,
+    node_query: str,
 ) -> None:
     global_id = to_global_id("Bar", "bar")
     response = client.post(
@@ -55,12 +84,36 @@ def test_node_query_existing_non_node_typename(
     }
 
 
+def test_node_typename_resolver(
+    client: TestClient,
+    qux_connection_query: str,
+    qux_nodes: Dict[str, Foo],
+) -> None:
+    response = client.post("/", json={"query": qux_connection_query})
+    assert response.status_code == 200
+    assert response.json() == {
+        "data": {
+            "quxes": {
+                "edges": [
+                    {
+                        "node": {
+                            "__typename": obj.__class__.__name__,
+                            "id": to_global_id("Baz", str(obj.id)),
+                        },
+                    }
+                    for obj in qux_nodes.values()
+                ],
+            },
+        }
+    }
+
+
 def test_connection_query(
     client: TestClient,
-    connection_query: str,
+    foo_connection_query: str,
     foo_nodes: Dict[str, Foo],
 ) -> None:
-    response = client.post("/", json={"query": connection_query})
+    response = client.post("/", json={"query": foo_connection_query})
     assert response.status_code == 200
     assert response.json() == {
         "data": {

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -6,7 +6,7 @@ from ariadne_relay import NodeObjectType, RelayQueryType
 from .conftest import Foo
 
 
-def test_default_connection_factory(type_defs: str, connection_query: str) -> None:
+def test_default_connection_factory(type_defs: str, foo_connection_query: str) -> None:
     test_nodes = [Foo(id=i) for i in range(10)]
 
     query_type = RelayQueryType()
@@ -16,7 +16,7 @@ def test_default_connection_factory(type_defs: str, connection_query: str) -> No
 
     schema = make_executable_schema(type_defs, query_type, test_type)
 
-    result = graphql_sync(schema, connection_query)
+    result = graphql_sync(schema, foo_connection_query)
     assert result.errors is None
     assert result.data == {
         "foos": {

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -1,30 +1,28 @@
+from typing import Dict
+
 from ariadne import InterfaceType, make_executable_schema, QueryType
 from graphql import graphql_sync
 from graphql_relay import to_global_id
 
-from ariadne_relay import NodeObjectType, resolve_node_query_sync
-from .conftest import Foo
+from ariadne_relay import NodeInterfaceType, RelayObjectType, RelayQueryType
+from .conftest import Foo, Qux
 
 
-def test_node_resolver(type_defs: str, node_query: str) -> None:
-    test_nodes = {str(i): Foo(id=i) for i in range(10)}
-
-    query_type = QueryType()
-    query_type.set_field("node", resolve_node_query_sync)
-
-    node_interface = InterfaceType(
-        "Node",
-        type_resolver=lambda obj, *_: obj.__class__.__name__,
+def test_node_instance_resolver(
+    type_defs: str,
+    foo_nodes: Dict[str, Foo],
+    foo_type: RelayObjectType,
+    query_type: RelayQueryType,
+    node_query: str,
+    node_interface_type: InterfaceType,
+) -> None:
+    schema = make_executable_schema(
+        type_defs,
+        foo_type,
+        query_type,
+        node_interface_type,
     )
-
-    test_type = NodeObjectType(
-        "Foo",
-        instance_resolver=lambda id, *_: test_nodes[id],
-    )
-
-    schema = make_executable_schema(type_defs, query_type, node_interface, test_type)
-
-    for obj in test_nodes.values():
+    for obj in foo_nodes.values():
         type_name = obj.__class__.__name__
         global_id = to_global_id(type_name, str(obj.id))
         result = graphql_sync(schema, node_query, variable_values={"id": global_id})
@@ -37,14 +35,67 @@ def test_node_resolver(type_defs: str, node_query: str) -> None:
         }
 
 
-def test_non_node_typename(type_defs: str, node_query: str) -> None:
-    query_type = QueryType()
-    query_type.set_field("node", resolve_node_query_sync)
-    node_interface = InterfaceType(
-        "Node",
-        type_resolver=lambda obj, *_: obj.__class__.__name__,
+def test_node_interface_instance_resolver(
+    type_defs: str,
+    baz_interface_type: NodeInterfaceType,
+    qux_nodes: Dict[str, Qux],
+    qux_type: RelayObjectType,
+    query_type: RelayQueryType,
+    node_query: str,
+    node_interface_type: InterfaceType,
+) -> None:
+    schema = make_executable_schema(
+        type_defs,
+        query_type,
+        baz_interface_type,
+        qux_type,
+        node_interface_type,
     )
-    schema = make_executable_schema(type_defs, query_type, node_interface)
+    for obj in qux_nodes.values():
+        global_id = to_global_id("Baz", str(obj.id))
+        result = graphql_sync(schema, node_query, variable_values={"id": global_id})
+        assert result.errors is None
+        assert result.data == {
+            "node": {
+                "__typename": obj.__class__.__name__,
+                "id": global_id,
+            }
+        }
+
+
+def test_node_typename_resolver(
+    type_defs: str,
+    baz_interface_type: NodeInterfaceType,
+    qux_nodes: Dict[str, Qux],
+    qux_type: RelayObjectType,
+    query_type: RelayQueryType,
+    qux_connection_query: str,
+) -> None:
+    schema = make_executable_schema(type_defs, query_type, baz_interface_type, qux_type)
+    result = graphql_sync(schema, qux_connection_query)
+    assert result.errors is None
+    assert result.data == {
+        "quxes": {
+            "edges": [
+                {
+                    "node": {
+                        "__typename": obj.__class__.__name__,
+                        "id": to_global_id("Baz", str(obj.id)),
+                    },
+                }
+                for obj in qux_nodes.values()
+            ],
+        },
+    }
+
+
+def test_non_node_typename(
+    type_defs: str,
+    query_type: QueryType,
+    node_query: str,
+    node_interface_type: InterfaceType,
+) -> None:
+    schema = make_executable_schema(type_defs, query_type, node_interface_type)
     global_id = to_global_id("Bar", "bar")
     result = graphql_sync(schema, node_query, variable_values={"id": global_id})
     assert result.errors is None


### PR DESCRIPTION
Implements the following:
* `NodeObjectType` has a new `typename_resolver`, which makes it possible to override the typename portion of generated global ids.  The default of using `GraphQLObjectType.name` is still in place, but now this can be overridden.
* Introduces a new `NodeInterfaceType` class, which permits the declaration of node resolvers for all types that implement an interface.

There should be no break in compatibility as a result of these changes.