### PR TITLE
Prohibit propagation node instance resolvers

### DIFF
--- a/ariadne_relay/node.py
+++ b/ariadne_relay/node.py
@@ -83,7 +83,7 @@ class NodeType:
                 self._resolve_id,
                 replace_existing,
             )
-        if self._resolve_instance is not None:
+        if self._resolve_instance is not None and graphql_type.name == self.name:
             _set_extension(
                 graphql_type,
                 INSTANCE_RESOLVER,

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -62,6 +62,16 @@ def test_node_interface_instance_resolver(
                 "id": global_id,
             }
         }
+        # a NodeInterfaceType instance resolver does not
+        # propagate to types that implement the interface
+        invalid_global_id = to_global_id("Qux", str(obj.id))
+        result = graphql_sync(
+            schema,
+            node_query,
+            variable_values={"id": invalid_global_id},
+        )
+        assert result.errors is None
+        assert result.data == {"node": None}
 
 
 def test_node_typename_resolver(


### PR DESCRIPTION
This addresses a bug where instance resolvers are incorrectly propagated via `NodeInterfaceType`.  An instance resolver only makes sense for a specific name, it should not be accessible from multiple names.