### PR TITLE
Restrict to ariadne<0.15.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
     packages=["ariadne_relay"],
     include_package_data=True,
     install_requires=[
-        "ariadne>=0.13.0",
+        "ariadne>=0.13.0,<0.15.0",
         "dataclasses; python_version < '3.7.0'",
         "graphql-relay==3.1.3",
     ],


### PR DESCRIPTION
Ariadne 0.15.0 depends on graphql-core>=3.2.0, but this is not compatible with ariadne-relay due to the graphql-relay dependency, which is not yet compatible with graphql-core 3.2.0.  Restricting to ariadne<0.15.0 until this is resolved.