### PR TITLE
Bump graphql-relay to 3.1.5

### DIFF
--- a/ariadne_relay/__init__.py
+++ b/ariadne_relay/__init__.py
@@ -1,13 +1,17 @@
-from graphql_relay import ConnectionCursor, Edge, from_global_id, PageInfo, to_global_id
-from graphql_relay.connection.array_connection import SizedSliceable
-from graphql_relay.connection.connection import (
+from graphql_relay import (
+    ConnectionCursor,
     ConnectionType,
+    Edge,
     EdgeConstructor,
     EdgeType,
+    from_global_id,
+    PageInfo,
     PageInfoConstructor,
     PageInfoType,
+    ResolvedGlobalId,
+    SizedSliceable,
+    to_global_id,
 )
-from graphql_relay.node.node import ResolvedGlobalId
 
 from .base import set_default_connection_factory
 from .connection import (

--- a/ariadne_relay/connection/base.py
+++ b/ariadne_relay/connection/base.py
@@ -17,13 +17,13 @@ try:
 except ImportError:  # Python < 3.8
     from typing_extensions import Protocol  # type: ignore
 
-from graphql_relay import connection_from_array_slice
-from graphql_relay.connection.array_connection import SizedSliceable
-from graphql_relay.connection.connection import (
+from graphql_relay import (
+    connection_from_array_slice,
     EdgeConstructor,
     EdgeType,
     PageInfoConstructor,
     PageInfoType,
+    SizedSliceable,
 )
 
 ConnectionType_T = TypeVar("ConnectionType_T", covariant=True)

--- a/ariadne_relay/connection/proxy.py
+++ b/ariadne_relay/connection/proxy.py
@@ -1,8 +1,6 @@
 from typing import TypeVar, Union
 
-from graphql_relay.connection.connection import (
-    ConnectionType as ReferenceConnectionType,
-)
+from graphql_relay import ConnectionType as ReferenceConnectionType
 
 from .base import BaseConnection, ConnectionArguments
 from .snake_case import SnakeCaseConnectionType

--- a/ariadne_relay/connection/reference.py
+++ b/ariadne_relay/connection/reference.py
@@ -1,7 +1,6 @@
 from typing import Optional
 
-from graphql_relay.connection.array_connection import SizedSliceable
-from graphql_relay.connection.connection import ConnectionType
+from graphql_relay import ConnectionType, SizedSliceable
 
 from .base import BaseConnection, ConnectionArguments
 

--- a/ariadne_relay/connection/snake_case.py
+++ b/ariadne_relay/connection/snake_case.py
@@ -6,13 +6,13 @@ try:
 except ImportError:  # Python < 3.8
     from typing_extensions import Protocol  # type: ignore
 
-from graphql_relay.connection.array_connection import SizedSliceable
-from graphql_relay.connection.connection import (
+from graphql_relay import (
     ConnectionCursor,
     EdgeConstructor,
     EdgeType,
     PageInfoConstructor,
     PageInfoType,
+    SizedSliceable,
 )
 
 from .base import (

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
     install_requires=[
         "ariadne>=0.13.0,<0.15.0",
         "dataclasses; python_version < '3.7.0'",
-        "graphql-relay==3.1.3",
+        "graphql-relay==3.1.5",
     ],
     extras_require={},
     classifiers=CLASSIFIERS,


### PR DESCRIPTION
Updating the graphql-relay dependency to 3.1.5, which allows simplifying imports.